### PR TITLE
Move default config values after .promu.yml parsing

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -37,13 +37,6 @@ var buildCmd = &cobra.Command{
 		runBuild()
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if !viper.IsSet("build.prefix") {
-			viper.Set("build.prefix", ".")
-		}
-		if !viper.IsSet("build.binaries") {
-			binaries := []map[string]string{{"name": info.Name, "path": "."}}
-			viper.Set("build.binaries", binaries)
-		}
 		if err := hasRequiredConfigurations("repository.path"); err != nil {
 			fatal(err)
 		}

--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -54,13 +54,6 @@ var crossbuildCmd = &cobra.Command{
 		runCrossbuild()
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if !viper.IsSet("crossbuild.platforms") {
-			platforms := defaultMainPlatforms
-			platforms = append(platforms, defaultARMPlatforms...)
-			platforms = append(platforms, defaultPowerPCPlatforms...)
-			platforms = append(platforms, defaultMIPSPlatforms...)
-			viper.Set("crossbuild.platforms", platforms)
-		}
 		if err := hasRequiredConfigurations("repository.path"); err != nil {
 			fatal(err)
 		}

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/progrium/go-shell"
+	shell "github.com/progrium/go-shell"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -87,13 +87,33 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
+	if err := viper.ReadInConfig(); err != nil {
+		fatalMsg("Error in config file", err)
+	}
 	if verbose {
-		if err != nil {
-			fmt.Println("Error in config file:", err)
-		} else {
-			fmt.Println("Using config file:", viper.ConfigFileUsed())
-		}
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+
+	setDefaultConfigValues()
+}
+
+func setDefaultConfigValues() {
+	if !viper.IsSet("build.binaries") {
+		binaries := []map[string]string{{"name": info.Name, "path": "."}}
+		viper.Set("build.binaries", binaries)
+	}
+	if !viper.IsSet("build.prefix") {
+		viper.Set("build.prefix", ".")
+	}
+	if !viper.IsSet("crossbuild.platforms") {
+		platforms := defaultMainPlatforms
+		platforms = append(platforms, defaultARMPlatforms...)
+		platforms = append(platforms, defaultPowerPCPlatforms...)
+		platforms = append(platforms, defaultMIPSPlatforms...)
+		viper.Set("crossbuild.platforms", platforms)
+	}
+	if !viper.IsSet("tarball.prefix") {
+		viper.Set("tarball.prefix", ".")
 	}
 }
 

--- a/cmd/tarball.go
+++ b/cmd/tarball.go
@@ -33,11 +33,6 @@ var tarballCmd = &cobra.Command{
 		binariesLocation := optArg(args, 0, ".")
 		runTarball(binariesLocation)
 	},
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if !viper.IsSet("tarball.prefix") {
-			viper.Set("tarball.prefix", ".")
-		}
-	},
 }
 
 // init prepares cobra flags


### PR DESCRIPTION
This also fix the default `build.binaries` config value for `promu crossbuild tarballs` command.

@grobie 