### PR TITLE
Print tarball upload completion

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -70,6 +70,7 @@ func uploadTarball(path string, f os.FileInfo, err error) error {
 			"--tag", info.Version,
 			"--name", fileName,
 			"--file", path)
+		fmt.Println(" > uploaded", fileName)
 	}
 
 	return nil


### PR DESCRIPTION
This gives a feedback of progress for uploading tarballs.
As a side effect, it will prevent timeouts in CircleCI triggered
by no output on stdout for too long.

@sdurrheimer 