### PR TITLE
Make CGO optional + use the builder base image for non-cgo

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -13,28 +13,4 @@ tarball:
     files:
         - LICENSE
         - NOTICE
-crossbuild:
-    platforms:
-        - linux/amd64
-        - linux/386
-        - darwin/amd64
-        - darwin/386
-        - windows/amd64
-        - windows/386
-        # - freebsd/amd64
-        # - freebsd/386
-        # - openbsd/amd64
-        # - openbsd/386
-        - netbsd/amd64
-        - netbsd/386
-        # - dragonfly/amd64
-        - linux/arm
-        - linux/arm64
-        # - freebsd/arm
-        # - openbsd/arm
-        - netbsd/arm
-        # - linux/ppc64
-        - linux/ppc64le
-        # - linux/mips64
-        # - linux/mips64le
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6.3-main
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-base
     REPO_PATH: github.com/prometheus/promu
     FULL_REPO_PATH: ${GOPATH%%:*}/src/$REPO_PATH
   pre:

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -116,6 +116,12 @@ func setDefaultConfigValues() {
 	if !viper.IsSet("tarball.prefix") {
 		viper.Set("tarball.prefix", ".")
 	}
+	if !viper.IsSet("go.version") {
+		viper.Set("go.version", "1.6.3")
+	}
+	if !viper.IsSet("go.cgo") {
+		viper.Set("go.cgo", false)
+	}
 }
 
 // warn prints a non-fatal err

--- a/doc/examples/.promu.yml
+++ b/doc/examples/.promu.yml
@@ -1,5 +1,7 @@
-go: 1.6.3
 verbose: false
+go:
+    version: 1.6.3
+    cgo: false
 repository:
     path: github.com/prometheus/prometheus
 build:


### PR DESCRIPTION
Associated with prometheus/golang-builder#13

This PR gives the ability to crossbuild with or without CGO. Non-CGO crossbuilds will be using the golang-builer base image which only contains Golang without any crossbuild toolchains.

Non-CGO builds should be faster now given that there is only a single lighter docker image for all platforms.

The CircleCI fail because it depends on the golang-builder PR. The later must be merged and successfully builded before merging this one.