### PR TITLE
windows: reduce dependency of go-shell, make build succeed on windows

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -23,6 +23,8 @@ import (
 	"github.com/progrium/go-shell"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/prometheus/promu/util/sh"
 )
 
 var (
@@ -168,7 +170,7 @@ type platformGroup struct {
 func (pg platformGroup) Build(repoPath string) error {
 	if platformsParam := strings.Join(pg.Platforms[:], " "); platformsParam != "" {
 		fmt.Printf("> running the %s builder docker image\n", pg.Name)
-		if err := docker("run --rm -t -v $PWD:/app", pg.DockerImage, "-i", repoPath, "-p", q(platformsParam)); err != nil {
+		if err := docker("run --rm -t -v $PWD:/app", pg.DockerImage, "-i", repoPath, "-p", sh.Quote(platformsParam)); err != nil {
 			return err
 		}
 	}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -51,7 +51,7 @@ func NewProjectInfo() ProjectInfo {
 	repo := repoLocation()
 	version, err := findVersion()
 	if err != nil {
-		fatalMsg("Unable to find project's version", err)
+		fmt.Println("Unable to find project's version", err)
 	}
 	return ProjectInfo{
 		Branch:   shellOutput("git rev-parse --abbrev-ref HEAD"),

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -29,8 +29,6 @@ import (
 )
 
 var (
-	sh           = shell.Run
-	q            = shell.Quote
 	docker       = shell.Cmd("docker").ErrFn()
 	buildContext = build.Default
 	goos         = buildContext.GOOS

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -21,11 +21,11 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/prometheus/promu/util/retry"
-
 	"github.com/progrium/go-shell"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/prometheus/promu/util/retry"
 )
 
 var (

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/promu/util/sh"
+)
+
+func TestSplitParameters(t *testing.T) {
+	in := `-a -tags 'netgo static_build'`
+	expect := []string{"-a", "-tags", `'netgo static_build'`}
+	got := sh.SplitParameters(in)
+	for i, g := range got {
+		if expect[i] != g {
+			t.Error("expected", expect[i], "got", g, "full output: ", strings.Join(got, "#"))
+		}
+	}
+}

--- a/cmd/tarball.go
+++ b/cmd/tarball.go
@@ -22,6 +22,8 @@ import (
 	"github.com/progrium/go-shell"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/prometheus/promu/util/sh"
 )
 
 // tarballCmd represents the tarball command
@@ -72,11 +74,11 @@ func runTarball(binariesLocation string) {
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		fatalMsg("Failed to create directory", err)
 	}
-	defer sh("rm -rf", tmpDir)
+	defer sh.RunCommand("rm", "-rf", tmpDir)
 
 	projectFiles := viper.GetStringSlice("tarball.files")
 	for _, file := range projectFiles {
-		sh("cp -a", file, dir)
+		sh.RunCommand("cp", "-a", file, dir)
 	}
 
 	if err := viper.UnmarshalKey("build.binaries", &binaries); err != nil {
@@ -85,7 +87,7 @@ func runTarball(binariesLocation string) {
 
 	for _, binary := range binaries {
 		binaryName := fmt.Sprintf("%s%s", binary.Name, ext)
-		sh("cp -a", shell.Path(binariesLocation, binaryName), dir)
+		sh.RunCommand("cp", "-a", shell.Path(binariesLocation, binaryName), dir)
 	}
 
 	if !fileExists(prefix) {
@@ -94,5 +96,5 @@ func runTarball(binariesLocation string) {
 
 	tar := fmt.Sprintf("%s.tar.gz", name)
 	fmt.Println(" >  ", tar)
-	sh("tar zcf", shell.Path(prefix, tar), "-C", tmpDir, name)
+	sh.RunCommand("tar", "zcf", shell.Path(prefix, tar), "-C", tmpDir, name)
 }

--- a/util/sh/sh.go
+++ b/util/sh/sh.go
@@ -1,0 +1,49 @@
+// Copyright © 2016 Prometheus Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// RunCommand executes a shell command.
+func RunCommand(name string, arg ...string) error {
+	if viper.GetBool("verbose") {
+		cmdText := name + " " + strings.Join(arg, " ")
+		fmt.Fprintln(os.Stderr, " + ", cmdText)
+	}
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Quote quotes a shell command parameter.
+func Quote(arg string) string {
+	return fmt.Sprintf("'%s'", strings.Replace(arg, "'", "'\\''", -1))
+}
+
+// SplitParameters splits shell command parameters, taking quouting in account.
+func SplitParameters(s string) []string {
+	r := regexp.MustCompile(`'[^']*'|[^ ]+`)
+	return r.FindAllString(s, -1)
+}


### PR DESCRIPTION
This makes promu successfully compile https://github.com/martinlindhe/wmi_exporter on Windows. Tested on Win 7.

The issues were:
* go-shell swallowed erroring commands, making it harder to debug
* go-shell Run() incorrectly escaped command line parameters, producing impossible command line. 

There is still some dependencies on go-shell, but they seem to be pretty trivial to replace with stdlib code.

Fixes #44 

This was triggered by trying to provide build info to wmi_exporter (https://github.com/martinlindhe/wmi_exporter/issues/24)