### PR TITLE
Bump default Go version to 1.7.1

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -72,7 +72,7 @@ func init() {
 	viper.BindPFlag("go.version", crossbuildCmd.Flags().Lookup("go"))
 
 	// Current bug in viper: SeDefault doesn't work with nested key
-	// viper.SetDefault("go.version", "1.6.3")
+	// viper.SetDefault("go.version", "1.7.1")
 	// platforms := defaultMainPlatforms
 	// platforms = append(platforms, defaultARMPlatforms...)
 	// platforms = append(platforms, defaultPowerPCPlatforms...)

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -117,7 +117,7 @@ func setDefaultConfigValues() {
 		viper.Set("tarball.prefix", ".")
 	}
 	if !viper.IsSet("go.version") {
-		viper.Set("go.version", "1.6.3")
+		viper.Set("go.version", "1.7.1")
 	}
 	if !viper.IsSet("go.cgo") {
 		viper.Set("go.cgo", false)


### PR DESCRIPTION
Apparently, recent MacOS versions really depend on it.

@sdurrheimer @grobie Is there anything else I have to do to build the next Prometheus release with Go1.7.1?

I need to cut a bugfix release ASAP, and I would like to use Go1.7.1 to fix MacOS issues.