### PR TITLE
return with error code on command failure

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -107,9 +107,8 @@ func runBuild() {
 		}
 		params = append(params, sh.SplitParameters(flags)...)
 		params = append(params, path.Join(repoPath, binary.Path))
-		err := sh.RunCommand("go", params...)
-		if err != nil {
-			fmt.Println("command failed:", err)
+		if err := sh.RunCommand("go", params...); err != nil {
+			fatalMsg("command failed: "+strings.Join(params, " "), err)
 		}
 	}
 }


### PR DESCRIPTION
While looking into a failure on appveyor [1], we noticed `command failed: fork/exec c:\go\bin\go.exe: invalid argument`, but appveyor failed to pick up the failure.

This patch quits on command failure using log.Fatal(), which signals an exit code to the OS so it can be picked up by appveyor.

The root cause of the failing command is still under investigation

1: https://ci.appveyor.com/project/martinlindhe/wmi-exporter/build/170