### PR TITLE
support compiling on ARM architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ format:
 
 $(FIRST_GOPATH)/bin/promu promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
-		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
+		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(patsubst arm%,arm,$(shell uname -m)))) \
 		$(GO) install github.com/prometheus/promu
 
 style:


### PR DESCRIPTION
Set GOARCH correctly for ARM devices, e.g. `uname -m` would output `armv7l`