### PR TITLE
Update Go version to 1.7.5

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -74,7 +74,7 @@ func init() {
 	viper.BindPFlag("go.version", crossbuildCmd.Flags().Lookup("go"))
 
 	// Current bug in viper: SeDefault doesn't work with nested key
-	// viper.SetDefault("go.version", "1.7.4")
+	// viper.SetDefault("go.version", "1.7.5")
 	// platforms := defaultMainPlatforms
 	// platforms = append(platforms, defaultARMPlatforms...)
 	// platforms = append(platforms, defaultPowerPCPlatforms...)

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -115,7 +115,7 @@ func setDefaultConfigValues() {
 		viper.Set("tarball.prefix", ".")
 	}
 	if !viper.IsSet("go.version") {
-		viper.Set("go.version", "1.7.4")
+		viper.Set("go.version", "1.7.5")
 	}
 	if !viper.IsSet("go.cgo") {
 		viper.Set("go.cgo", false)


### PR DESCRIPTION
@sdurrheimer As far as I can see, golang-builder is prepared for this.
@brian-brazil So that Prometheus 1.5.2 comes compiled with Go 1.7.5.