### PR TITLE
Use go env to fetch GOPATH to support Go 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 GO           ?= GO15VENDOREXPERIMENT=1 go
-FIRST_GOPATH := $(firstword $(subst :, ,$(GOPATH)))
+FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU        ?= $(FIRST_GOPATH)/bin/promu
 pkgs          = $(shell $(GO) list ./... | grep -v /vendor/)
 


### PR DESCRIPTION
Go 1.8 do not require env GOPATH to be set and make will fail if it isn't set.

@sdurrheimer 