### PR TITLE
Add promu checksum command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,6 @@ deployment:
     owner: prometheus
     commands:
       - promu crossbuild tarballs
+      - promu checksum .tarballs
       - promu release .tarballs
       - mkdir $CIRCLE_ARTIFACTS/releases/ && cp -a .tarballs/* $CIRCLE_ARTIFACTS/releases/

--- a/cmd/checksum.go
+++ b/cmd/checksum.go
@@ -1,0 +1,106 @@
+// Copyright © 2017 Prometheus Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	checksumsFilename = "sha256sums.txt"
+)
+
+// checksumCmd represents the command calculating checksums for all files in a
+// given directory and writing the result to a checksums file.
+var checksumCmd = &cobra.Command{
+	Use:   "checksum [<location>]",
+	Short: "Calculate the SHA256 checksum for each file in the given location",
+	Long:  `Calculate the SHA256 checksum for each file in the given location`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runChecksum(optArg(args, 0, "."))
+	},
+}
+
+// init prepares cobra flags
+func init() {
+	Promu.AddCommand(checksumCmd)
+}
+
+func runChecksum(path string) {
+	checksums, err := calculateSHA256s(path)
+	if err != nil {
+		fatalMsg("Failed to calculate checksums", err)
+	}
+
+	file, err := os.Create(filepath.Join(path, checksumsFilename))
+	if err != nil {
+		fatalMsg("Failed to create checksums file", err)
+	}
+	defer file.Close()
+	for _, c := range checksums {
+		if _, err := fmt.Fprintf(file, "%x  %s\n", c.checksum, c.filename); err != nil {
+			fatalMsg("Failed to write to checksums file", err)
+		}
+	}
+}
+
+type checksumSHA256 struct {
+	filename string
+	checksum []byte
+}
+
+// calculateSHA256s calculates the sha256 checksum for each file in the given
+// path and returns a checksumSHA256 type in the order returned of
+// filepath.Walk.
+func calculateSHA256s(path string) ([]checksumSHA256, error) {
+	var checksums []checksumSHA256
+	path = fmt.Sprintf("%s%c", filepath.Clean(path), filepath.Separator)
+	calculateSHA256 := func(filepath string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if f.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(filepath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		hash := sha256.New()
+		if _, err = io.Copy(hash, file); err != nil {
+			return err
+		}
+		checksums = append(checksums, checksumSHA256{
+			filename: strings.TrimPrefix(filepath, path),
+			checksum: hash.Sum(nil),
+		})
+
+		return nil
+	}
+	if err := filepath.Walk(path, calculateSHA256); err != nil {
+		return nil, err
+	}
+	return checksums, nil
+}

--- a/cmd/checksum_test.go
+++ b/cmd/checksum_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2017 Prometheus Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"crypto/sha256"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCalculateSHA256s(t *testing.T) {
+	dir, err := ioutil.TempDir("", "promu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		filename = "testfile"
+		location = filepath.Join(dir, filename)
+		content  = []byte("temporary file's content")
+		checksum = sha256.Sum256(content)
+	)
+	if err := ioutil.WriteFile(location, content, 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := calculateSHA256s(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []checksumSHA256{
+		{
+			filename: filename,
+			checksum: checksum[:],
+		},
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("want checksums %+v, got %+v", want, got)
+	}
+}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -65,6 +65,13 @@ func runRelease(tarballsLocation string) {
 }
 
 func releaseTarball(path string, f os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+	if f.IsDir() {
+		return nil
+	}
+
 	fileName := filepath.Base(path)
 	tarPattern := fmt.Sprintf("%s-%s.*.tar.gz", info.Name, info.Version)
 


### PR DESCRIPTION
This is essentially a reimplementation of sha256sum, but removing the
directory name, thus removing the need to use more involved cd/grep
usage in circle.yml files.

I'm not sure if it's worth to reimplement such functionality, but it
reduces the amount of shell scripts and it seems that what we're aiming
for with promu?

Fixes #18 

@sdurrheimer @juliusv @mdlayher