### PR TITLE
Fix #65 by building only ARM compatible platforms

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -37,13 +37,20 @@ var (
 		"dragonfly/amd64",
 	}
 	defaultARMPlatforms = []string{
-		"linux/arm", "linux/arm64", "freebsd/arm", "openbsd/arm", "netbsd/arm",
+		"linux/armv5", "linux/armv6", "linux/armv7", "linux/arm64", "freebsd/armv6", "freebsd/armv7",
+		"openbsd/armv7", "netbsd/armv6", "netbsd/armv7",
 	}
 	defaultPowerPCPlatforms = []string{
 		"linux/ppc64", "linux/ppc64le",
 	}
 	defaultMIPSPlatforms = []string{
 		"linux/mips64", "linux/mips64le",
+	}
+	armPlatformsAliases = map[string][]string{
+		"linux/arm":   {"linux/armv5", "linux/armv6", "linux/armv7"},
+		"freebsd/arm": {"freebsd/armv6", "freebsd/armv7"},
+		"openbsd/arm": {"openbsd/armv7"},
+		"netbsd/arm":  {"netbsd/armv6", "netbsd/armv7"},
 	}
 )
 
@@ -124,6 +131,8 @@ func runCrossbuild() {
 			} else {
 				warn(errors.New("MIPS architectures are only available with Go 1.6+"))
 			}
+		case stringInMapKeys(platform, armPlatformsAliases):
+			armPlatforms = append(armPlatforms, armPlatformsAliases[platform]...)
 		default:
 			unknownPlatforms = append(unknownPlatforms, platform)
 		}

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -203,6 +203,11 @@ func stringInSlice(needle string, haystack []string) bool {
 	return false
 }
 
+func stringInMapKeys(needle string, haystack map[string][]string) bool {
+	_, ok := haystack[needle]
+	return ok
+}
+
 func hasRequiredConfigurations(configVars ...string) error {
 	for _, configVar := range configVars {
 		if !viper.IsSet(configVar) {


### PR DESCRIPTION
+ providing retro-compatibility with existing .promu.yml files via
aliases

Linked to prometheus/golang-builder#28