### PR TITLE
Treat . as all when determining which binaries to build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -129,7 +129,7 @@ func runBuild(binariesString string) {
 		fatal(errors.Wrap(err, "Failed to Unmashal binaries"))
 	}
 
-	if binariesString == "all" {
+	if binariesString == "all" || binariesString == "." {
 		buildAll(ext, prefix, ldflags, binaries)
 		return
 	}


### PR DESCRIPTION
@sdurrheimer @carlpett treat `.` as `all` when we parse binary names for build command

should fix https://github.com/martinlindhe/wmi_exporter/issues/119