### PR TITLE
Feature: add check_license.sh

### DIFF
--- a/cmd/check_licenses.go
+++ b/cmd/check_licenses.go
@@ -1,0 +1,146 @@
+// Copyright © 2016 Prometheus Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// validSourceExtensions is a slice of strings
+	// representing the file suffix of source code files to inspect
+	validSourceExtensions []string
+
+	// defaultSourceExtensions is a slice of strings
+	// representing the file suffix of source code files to inspect
+	// defaulted to only include go source files.
+	defaultSourceExtensions = []string{".go"}
+
+	// validHeaderStrings is a slice of strings that must exist in a header.
+	validHeaderStrings = []string{"copyright", "generated"}
+
+	// checkLicensesCmd represents the check_licenses command.
+	checkLicensesCmd = &cobra.Command{
+		Use:   "check_licenses [<location>]",
+		Short: "Inspect source files for each file in a given directory",
+		Long: `Inspect source files for each file in a given directory 
+and report those that are missing their header`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(validSourceExtensions)
+			runCheckLicenses(optArg(args, 0, "."), validSourceExtensions)
+		},
+	}
+)
+
+// init prepares cobra flags and attaches the checkLicensesCmd to Promu
+func init() {
+	checkLicensesCmd.PersistentFlags().StringSliceVar(&validSourceExtensions, "extensions", defaultSourceExtensions, "comma separated list of valid source code extenstions (default is .go)")
+
+	Promu.AddCommand(checkLicensesCmd)
+}
+
+func runCheckLicenses(path string, extensions []string) {
+	path = fmt.Sprintf("%s%c", filepath.Clean(path), filepath.Separator)
+
+	filesMissingHeaders, err := checkLicenses(path, extensions)
+	if err != nil {
+		fatal(errors.Wrap(err, "Failed to check files for license header"))
+	}
+
+	for _, file := range filesMissingHeaders {
+		fmt.Println(file)
+	}
+}
+
+func checkLicenses(path string, extensions []string) ([]string, error) {
+	var missingHeaders []string
+	walkFunc := func(filepath string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if f.IsDir() {
+			return nil
+		}
+
+		if strings.HasPrefix(filepath, "vendor/") {
+			return nil
+		}
+
+		if !suffixInSlice(f.Name(), extensions) {
+			return nil
+		}
+
+		file, err := os.Open(filepath)
+		if err != nil {
+			return err
+		}
+
+		defer file.Close()
+
+		pass := false
+		scanner := bufio.NewScanner(file)
+		for i := 0; i < 3; i++ {
+			scanner.Scan()
+			if stringContainedInSlice(strings.ToLower(scanner.Text()), validHeaderStrings) {
+				pass = true
+			}
+		}
+
+		if !pass {
+			missingHeaders = append(missingHeaders, filepath)
+		}
+
+		return nil
+	}
+
+	err := filepath.Walk(path, walkFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	return missingHeaders, nil
+}
+
+func stringContainedInSlice(needle string, haystack []string) bool {
+	exists := false
+	for _, h := range haystack {
+		if strings.Contains(needle, h) {
+			exists = true
+			break
+		}
+	}
+
+	return exists
+}
+
+func suffixInSlice(needle string, haystack []string) bool {
+	exists := false
+	for _, h := range haystack {
+		if strings.HasSuffix(needle, h) {
+			exists = true
+			break
+		}
+	}
+
+	return exists
+}


### PR DESCRIPTION
As described in issue #58 there is no automated script to check that all
source files contain a license header.

Prometheus already has a script provided by @jonboulle and I have simply
copied that script and applied it to this code base.

Example output:
```
github.com/prometheus/promu on  master [?]
➜ make check_license
>> checking license header
-e license header checking failed:
-e   ./util/sh/sh_test.go
make: *** [check_license] Error 255
```

All credit to @jonboulle for the initial script.

This closes #58