### PR TITLE
Fix build on SmartOS by not setting gcc's -static flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -174,7 +174,7 @@ func getLdflags(info ProjectInfo) string {
 		ldflags = append(ldflags, fmt.Sprintf("-X main.Version=%s", info.Version))
 	}
 
-	if goos != "darwin" && !stringInSlice(`-extldflags '-static'`, ldflags) {
+	if goos != "darwin" && goos != "solaris" && !stringInSlice(`-extldflags '-static'`, ldflags) {
 		ldflags = append(ldflags, `-extldflags '-static'`)
 	}
 


### PR DESCRIPTION
Fix https://github.com/prometheus/node_exporter/issues/698 

Install setup from smartos image: base-64-lts 16.4.1

>   pkgin in scmgit-base gcc49
>   pkgin in go-1.9
>   pkgin in git-2.14.1
>   go get github.com/prometheus/node_exporter
>   cd go/src/github.com/prometheus/node_exporter/
>   pkgin in gmake
>   make

Here is the output before this change. 

> formatting code
> vetting code
> running staticcheck
> building binaries
>   node_exporter`
`# github.com/prometheus/node_exporter
/opt/local/go/pkg/tool/solaris_amd64/link: running gcc failed: exit status 1
ld: fatal: library -lsocket: not found
ld: fatal: library -lnsl: not found
ld: fatal: library -lsendfile: not found
ld: fatal: library -lc: not found
ld: fatal: file processing errors. No output written to $WORK/github.com/prometheus/node_exporter/_obj/exe/a.out
collect2: error: ld returned 1 exit status
!! command failed: build -o /root/go/src/github.com/prometheus/node_exporter/node_exporter -ldflags -X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.Version=0.15.0 -X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.Revision=a40f7e78dacf53374978e802e013668c22419e7f -X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.Branch=master -X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.BuildUser=root@fry -X github.com/prometheus/node_exporter/vendor/github.com/prometheus/common/version.BuildDate=20171214-14:54:45  -extldflags '-static' -a -tags 'netgo static_build' github.com/prometheus/node_exporter: exit status 2
Makefile:109: recipe for target 'build' failed
make: *** [build] Error 1`