### PR TITLE
Avoid bind-mounting to allow building with a remote docker engine

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -172,9 +174,33 @@ func (pg platformGroup) Build(repoPath string) error {
 		return errors.Wrapf(err, "couldn't get current working directory")
 	}
 
-	return sh.RunCommand("docker", "run", "--rm", "-t",
-		"-v", fmt.Sprintf("%s:/app", cwd),
+	ctrName := "promu-crossbuild-" + pg.Name + strconv.FormatInt(time.Now().Unix(), 10)
+	err = sh.RunCommand("docker", "create", "-t",
+		"--name", ctrName,
 		pg.DockerImage,
 		"-i", repoPath,
 		"-p", platformsParam)
+	if err != nil {
+		return err
+	}
+
+	err = sh.RunCommand("docker", "cp",
+		cwd+"/.",
+		ctrName+":/app/")
+	if err != nil {
+		return err
+	}
+
+	err = sh.RunCommand("docker", "start", "-a", ctrName)
+	if err != nil {
+		return err
+	}
+
+	err = sh.RunCommand("docker", "cp", "-a",
+		ctrName+":/app/.build",
+		cwd+"/.build")
+	if err != nil {
+		return err
+	}
+	return sh.RunCommand("docker", "rm", "-f", ctrName)
 }


### PR DESCRIPTION
Fixes #94 

This works when running against a remote Docker engine (for example, in CircleCI), but this _is_ slower, since it adds the step of recursively copying the current working directory into the build container, rather than being bind-mounted in.

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>