### PR TITLE
Use latest go1.10 patch version by default

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -78,7 +78,7 @@ func init() {
 	viper.BindPFlag("go.version", crossbuildCmd.Flags().Lookup("go"))
 
 	// Current bug in viper: SeDefault doesn't work with nested key
-	// viper.SetDefault("go.version", "1.10.0")
+	// viper.SetDefault("go.version", "1.10")
 	// platforms := defaultMainPlatforms
 	// platforms = append(platforms, defaultARMPlatforms...)
 	// platforms = append(platforms, defaultPowerPCPlatforms...)

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -122,7 +122,7 @@ func setDefaultConfigValues() {
 		viper.Set("tarball.prefix", ".")
 	}
 	if !viper.IsSet("go.version") {
-		viper.Set("go.version", "1.10.0")
+		viper.Set("go.version", "1.10")
 	}
 	if !viper.IsSet("go.cgo") {
 		viper.Set("go.cgo", false)


### PR DESCRIPTION
Update our go version to the latest available release currently requires
touching several files across multiple repositories. Simplify the
process a bit by always using the latest go1.10 minor version regardless
of the specific patch version.

A approval process is still available in prometheus/golang-builder.

@brian-brazil @sdurrheimer 