### PR TITLE
cmd: allow to customize nested options via env variables

### DIFF
--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -89,7 +89,8 @@ func initConfig() error {
 	viper.SetConfigName(".promu") // name of config file (without extension)
 	viper.AddConfigPath(".")      // look for config in the working directory
 	viper.SetEnvPrefix("promu")
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv()                                   // read in environment variables that match
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // replacing dots in key names with '_'
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
As most shells don't allow dots in environment variable names, it's not
possible to customize nested options via environment variable, like:

PROMU_BUILD_FLAGS='<flags>'

The patch fixes this by asking viper to replace all dots in config key
names with '_' while scanning the environment.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>