### PR TITLE
Add ppc64 build workaround

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -178,6 +178,11 @@ func getLdflags(info ProjectInfo) string {
 		ldflags = append(ldflags, `-extldflags '-static'`)
 	}
 
+	// Workaround for https://github.com/golang/go/issues/13192.
+	if goarch == "ppc64" && !stringInSlice(`-linkmode=external`, ldflags) {
+		ldflags = append(ldflags, `-linkmode=external`)
+	}
+
 	return strings.Join(ldflags[:], " ")
 }
 


### PR DESCRIPTION
Due to https://github.com/golang/go/issues/13192, we need to pass in
a tweak to the ldflags.

Signed-off-by: Ben Kochie <superq@gmail.com>