### PR TITLE
[issue #102] Add option to disable static linking

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -174,7 +174,8 @@ func getLdflags(info ProjectInfo) string {
 		ldflags = append(ldflags, fmt.Sprintf("-X main.Version=%s", info.Version))
 	}
 
-	if goos != "darwin" && goos != "solaris" && !stringInSlice(`-extldflags '-static'`, ldflags) {
+	staticBinary := viper.GetBool("build.static")
+	if staticBinary && goos != "darwin" && goos != "solaris" && !stringInSlice(`-extldflags '-static'`, ldflags) {
 		ldflags = append(ldflags, `-extldflags '-static'`)
 	}
 

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -111,6 +111,9 @@ func setDefaultConfigValues() {
 	if !viper.IsSet("build.prefix") {
 		viper.Set("build.prefix", ".")
 	}
+	if !viper.IsSet("build.static") {
+		viper.Set("build.static", true)
+	}
 	if !viper.IsSet("crossbuild.platforms") {
 		platforms := defaultMainPlatforms
 		platforms = append(platforms, defaultARMPlatforms...)


### PR DESCRIPTION
Certain binaries (e.g. node_exporter) require dynamic linking for certain
system functions.  This change adds an option "build.static" to turn off
the default static linking.
Fixes #102 