### PR TITLE
fix crossbuild nested .build directories

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -218,7 +218,7 @@ func (pg platformGroup) Build(repoPath string) error {
 	}
 
 	err = sh.RunCommand("docker", "cp", "-a",
-		ctrName+":/app/.build",
+		ctrName+":/app/.build/.",
 		cwd+"/.build")
 	if err != nil {
 		return err


### PR DESCRIPTION
The crossbuild command was copying the .build directory out of the
container and creating a local .build/.build directory.  This
changes the copy operation to correctly get the contents from the
container instead of copying the directory itself.