### PR TITLE
Make extldflags extensible by configuration. 

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -170,9 +170,13 @@ func getLdflags(info ProjectInfo) string {
 		ldflags = append(ldflags, fmt.Sprintf("-X main.Version=%s", info.Version))
 	}
 
-	staticBinary := config.Build.Static
-	if staticBinary && goos != "darwin" && goos != "solaris" && !stringInSlice(`-extldflags '-static'`, ldflags) {
-		ldflags = append(ldflags, `-extldflags '-static'`)
+	extLDFlags := config.Build.ExtLDFlags
+	if config.Build.Static && goos != "darwin" && goos != "solaris" && !stringInSlice("-static", extLDFlags) {
+		extLDFlags = append(extLDFlags, "-static")
+	}
+
+	if len(extLDFlags) > 0 {
+		ldflags = append(ldflags, fmt.Sprintf("-extldflags '%s'", strings.Join(extLDFlags, " ")))
 	}
 
 	return strings.Join(ldflags[:], " ")

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -42,11 +42,12 @@ type Binary struct {
 // Config contains the Promu Command Configuration
 type Config struct {
 	Build struct {
-		Binaries []Binary
-		Flags    string
-		LDFlags  string
-		Prefix   string
-		Static   bool
+		Binaries   []Binary
+		Flags      string
+		LDFlags    string
+		ExtLDFlags []string
+		Prefix     string
+		Static     bool
 	}
 	Crossbuild struct {
 		Platforms []string

--- a/doc/examples/basic/extldflags.yml
+++ b/doc/examples/basic/extldflags.yml
@@ -1,0 +1,10 @@
+repository:
+    path: github.com/prometheus/promu
+build:
+    binaries:
+        - name: extldflags
+          path: doc/examples/basic
+    extldflags:
+      - -ltesting
+      - -ltesting01
+

--- a/main_test.go
+++ b/main_test.go
@@ -69,6 +69,12 @@ func errcheck(t *testing.T, err error, output string) {
 	}
 }
 
+func assertTrue(t *testing.T, cond bool) {
+	if !cond {
+		t.Error("condition isn't true")
+	}
+}
+
 func assertFileExists(t *testing.T, filepath string) {
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		log.Print("file does not exist: ", filepath)
@@ -122,6 +128,16 @@ func TestPromuBuild_AltConfig(t *testing.T) {
 	errcheck(t, err, string(output))
 
 	assertFileExists(t, path.Join(outputDir, "alt-basic-example"))
+}
+
+func TestPromuBuild_ExtLDFlags(t *testing.T) {
+	outputDir := path.Join(testOutputDir, "extldflags")
+	promuConfig := path.Join(promuExamplesBasic, "extldflags.yml")
+	cmd := exec.Command(promuBinaryAbsPath, "build", "-v", "--config", promuConfig, "--prefix", outputDir)
+	output, err := cmd.CombinedOutput()
+	assertTrue(t, strings.Contains(string(output), "-extldflags '-ltesting -ltesting01 -static'"))
+	errcheck(t, err, string(output))
+	assertFileExists(t, path.Join(outputDir, "extldflags"))
 }
 
 func TestTarball(t *testing.T) {


### PR DESCRIPTION
This commit implements a new configuration option
for allowing the extldflags to be extended for
specific build requirements (such as additional libraries).

The default case (If no option is provided) remains the same
(the -static flag is passed).

Tests are provided for validating the functionality.

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@linaro.org>