### PR TITLE
Remove --broken from git describe

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -137,5 +137,5 @@ func findVersion() (string, error) {
 		}
 	}
 
-	return shellOutput("git describe --tags --always --dirty --broken"), nil
+	return shellOutput("git describe --tags --always --dirty"), nil
 }


### PR DESCRIPTION
Circle-ci git binary version does not have this option.

Since there is little reason we are workinig on a corrupt repo
we can remove this option so that we can build safely on
Circle-ci.

Signed-off-by: Sylvain Rabot <s.rabot@lectra.com>