### PR TITLE
Makefile: fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@
 
 include Makefile.common
 
-$(FIRST_GOPATH)/bin/promu:
+.PHONY: build
+build:
+	@echo ">> installing promu"
 	GO111MODULE=$(GO111MODULE) GOOS= GOARCH= $(GO) install github.com/prometheus/promu
-
-.PHONY: $(FIRST_GOPATH)/bin/promu
+	@echo ">> rebuilding binaries using promu"
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)


### PR DESCRIPTION
Overriding the <gopath>/promu target causes a warning during build.
This updates the build to fix the warning and first build promu by
using the go compiler directly, and then using the just built promu
to rebuild itself.

> Makefile:17: warning: overriding recipe for target '/home/pgier/go/bin/promu'
Makefile.common:236: warning: ignoring old recipe for target '/home/pgier/go/bin/promu'
