### PR TITLE
cmd/release: create release in GitHub if none exists

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -15,10 +15,15 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -35,7 +40,16 @@ var (
 	allowedRetries = releasecmd.Flag("retry", "Number of retries to perform when upload fails").
 			Default("2").Int()
 	releaseLocation = releasecmd.Arg("location", "Location of files to release").Default(".").Strings()
+	versionRe       = regexp.MustCompile(`^\d+\.\d+\.\d+(-.+)?$`)
 )
+
+func isPrerelease(version string) (bool, error) {
+	matches := versionRe.FindStringSubmatch(version)
+	if matches == nil {
+		return false, errors.Errorf("invalid version %s", version)
+	}
+	return matches[1] != "", nil
+}
 
 func runRelease(location string) {
 	token := os.Getenv("GITHUB_TOKEN")
@@ -58,11 +72,18 @@ func runRelease(location string) {
 		),
 	)
 
+	prerelease, err := isPrerelease(projInfo.Version)
+	if err != nil {
+		fatal(err)
+	}
+
 	// Find the GitHub release matching with the tag. We need to list all
 	// releases because it is the only way to get draft releases too.
-	tag := fmt.Sprintf("v%s", projInfo.Version)
-	var release *github.RepositoryRelease
-	opts := &github.ListOptions{}
+	var (
+		release *github.RepositoryRelease
+		opts    = &github.ListOptions{}
+		tag     = fmt.Sprintf("v%s", projInfo.Version)
+	)
 	for {
 		releases, resp, err := client.Repositories.ListReleases(ctx, projInfo.Owner, projInfo.Name, opts)
 		if err != nil {
@@ -80,7 +101,31 @@ func runRelease(location string) {
 		opts.Page = resp.NextPage
 	}
 	if release == nil {
-		fatal(errors.Errorf("failed to find a release with tag %s", tag))
+		// Create a draft release if none exists already.
+		var (
+			err        error
+			draft      = true
+			name, body = getChangelog(projInfo.Version, readChangelog())
+		)
+		if name != "" {
+			release, _, err = client.Repositories.CreateRelease(
+				ctx,
+				projInfo.Owner,
+				projInfo.Name,
+				&github.RepositoryRelease{
+					TagName:         &tag,
+					TargetCommitish: &projInfo.Revision,
+					Name:            &name,
+					Body:            &body,
+					Draft:           &draft,
+					Prerelease:      &prerelease,
+				})
+			if err != nil {
+				fatal(errors.Wrap(err, fmt.Sprintf("failed to create a draft release for %s", projInfo.Version)))
+			}
+		} else {
+			fmt.Println("fail to parse CHANGELOG.md")
+		}
 	}
 
 	if err := filepath.Walk(location, releaseFile(ctx, client, release)); err != nil {
@@ -175,4 +220,42 @@ func releaseFile(ctx context.Context, client *github.Client, release *github.Rep
 
 		return nil
 	}
+}
+
+func readChangelog() io.ReadCloser {
+	f, err := os.Open("CHANGELOG.md")
+	if err != nil {
+		fmt.Printf("fail to read CHANGELOG.md: %v\n", err)
+		return ioutil.NopCloser(&bytes.Buffer{})
+	}
+	return f
+}
+
+// getChangelog returns the changelog's header and body for a given version.
+func getChangelog(version string, rc io.ReadCloser) (string, string) {
+	defer rc.Close()
+
+	var (
+		scanner = bufio.NewScanner(rc)
+		s       []string
+		header  string
+		reading bool
+	)
+	for (len(s) == 0 || reading) && scanner.Scan() {
+		text := scanner.Text()
+		switch {
+		case strings.HasPrefix(text, "## "+version+" "):
+			reading = true
+			header = strings.TrimSpace(strings.TrimPrefix(text, "##"))
+		case strings.HasPrefix(text, "##"):
+			reading = false
+		case reading:
+			if len(s) == 0 && strings.TrimSpace(text) == "" {
+				continue
+			}
+			s = append(s, scanner.Text())
+		}
+	}
+
+	return header, strings.Join(s, "\n")
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -247,7 +247,7 @@ func getChangelog(version string, rc io.ReadCloser) (string, string) {
 		case strings.HasPrefix(text, "## "+version+" "):
 			reading = true
 			header = strings.TrimSpace(strings.TrimPrefix(text, "##"))
-		case strings.HasPrefix(text, "##"):
+		case strings.HasPrefix(text, "## "):
 			reading = false
 		case reading:
 			if len(s) == 0 && strings.TrimSpace(text) == "" {

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -111,6 +111,25 @@ This is the first stable release.
 * [FEATURE] Some feature.
 `,
 		},
+		{
+			in: `## 1.0.0 / 2016-01-02
+
+### Breaking changes!
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+
+## 0.0.1 / 2016-01-02
+
+* [BUGFIX] Another fix.`,
+			version: "1.0.0",
+			header:  "1.0.0 / 2016-01-02",
+			body: `### Breaking changes!
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+`,
+		},
 	} {
 		tc := tc
 		t.Run("", func(t *testing.T) {

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestIsPrerelease(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+
+		exp bool
+		err bool
+	}{
+		{
+			version: "1.0.0",
+			exp:     false,
+		},
+		{
+			version: "1.0.0-rc0",
+			exp:     true,
+		},
+		{
+			version: "x1.0.0-rc0",
+			err:     true,
+		},
+	} {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			got, err := isPrerelease(tc.version)
+			if err != nil && !tc.err {
+				t.Fatalf("expected no error, got %v", err)
+				return
+			}
+			if got != tc.exp {
+				t.Fatalf("expected %t, got %t", tc.exp, got)
+			}
+		})
+	}
+
+}
+
+func TestGetChangelog(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		version string
+
+		header string
+		body   string
+	}{
+		{
+			in:      "",
+			version: "1.0.0",
+			header:  "",
+			body:    "",
+		},
+		{
+			in: `## 1.0.0 / 2016-01-02
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.`,
+			version: "1.0.0",
+			header:  "1.0.0 / 2016-01-02",
+			body: `* [BUGFIX] Some fix.
+* [FEATURE] Some feature.`,
+		},
+		{
+			in: `## 1.0.0 / 2016-01-02
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+
+## 0.0.1 / 2016-01-02
+
+* [BUGFIX] Another fix.`,
+			version: "1.0.0",
+			header:  "1.0.0 / 2016-01-02",
+			body: `* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+`,
+		},
+		{
+			in: `## 1.0.0 / 2016-01-02
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+
+## 0.0.1 / 2016-01-01
+
+* [BUGFIX] Another fix.`,
+			version: "0.0.1",
+			header:  "0.0.1 / 2016-01-01",
+			body:    `* [BUGFIX] Another fix.`,
+		},
+		{
+			in: `## 1.0.0 / 2016-01-02
+This is the first stable release.
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+
+## 0.0.1 / 2016-01-02
+
+* [BUGFIX] Another fix.`,
+			version: "1.0.0",
+			header:  "1.0.0 / 2016-01-02",
+			body: `This is the first stable release.
+
+* [BUGFIX] Some fix.
+* [FEATURE] Some feature.
+`,
+		},
+	} {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			header, body := getChangelog(tc.version, ioutil.NopCloser(bytes.NewBufferString(tc.in)))
+			if body != tc.body {
+				t.Fatalf("expected body %q, got %q", tc.body, body)
+			}
+			if header != tc.header {
+				t.Fatalf("expected header %q, got %q", tc.header, header)
+			}
+		})
+	}
+}

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Prometheus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (


### PR DESCRIPTION
This would facilitate the release process as a maintainer wouldn't have to prepare the GitHub release in advance before pushing a tag (ref Prometheus' [RELEASE.md](https://github.com/prometheus/prometheus/blob/master/RELEASE.md#draft-the-new-release) page). The last manual step will be to push the "Publish release" button.
I tested this change with a repository of mine and it worked fine (see https://github.com/simonpasquier/instrumented_app/releases).