### PR TITLE
Use env var GO if available

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -79,10 +79,11 @@ func buildBinary(ext string, prefix string, ldflags string, binary Binary) {
 		"-ldflags", ldflags,
 	}
 
+	gobin := GoBin()
 	params = append(params, sh.SplitParameters(flags)...)
 	params = append(params, path.Join(repoPath, binary.Path))
-	info("Building binary: " + "go " + strings.Join(params, " "))
-	if err := sh.RunCommand("go", params...); err != nil {
+	info("Building binary: " + gobin + " " + strings.Join(params, " "))
+	if err := sh.RunCommand(gobin, params...); err != nil {
 		fatal(errors.Wrap(err, "command failed: "+strings.Join(params, " ")))
 	}
 }
@@ -192,4 +193,14 @@ func UserFunc() (interface{}, error) {
 // RepoPathFunc returns the repository path.
 func RepoPathFunc() interface{} {
 	return config.Repository.Path
+}
+
+func GoBin() string {
+	bin := os.Getenv("GO")
+
+	if len(bin) == 0 {
+		bin = "go"
+	}
+
+	return bin
 }

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/promu/cmd"
 )
 
 const (
@@ -55,7 +57,7 @@ func setup() {
 	if !os.IsExist(err) && err != nil {
 		log.Fatal(err)
 	}
-	cmd := exec.Command("go", "build", "-o", promuBinaryAbsPath)
+	cmd := exec.Command(cmd.GoBin(), "build", "-o", promuBinaryAbsPath)
 	output, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err, string(output))


### PR DESCRIPTION
Allows you to compile with a different GO toolchain when you have several version installed on your system.