### PR TITLE
Fix cgo builds on illumos by avoiding static linking

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -172,7 +172,7 @@ func getLdflags(info repository.Info) string {
 	}
 
 	extLDFlags := config.Build.ExtLDFlags
-	if config.Build.Static && goos != "darwin" && goos != "solaris" && !stringInSlice("-static", extLDFlags) {
+	if config.Build.Static && goos != "darwin" && goos != "solaris" && goos != "illumos" && !stringInSlice("-static", extLDFlags) {
 		extLDFlags = append(extLDFlags, "-static")
 	}
 


### PR DESCRIPTION
Fix prometheus/node_exporter#1836.  The underlying bug is essentially the same as prometheus/node_exporter#698, and the fix here is essentially the same as #88.  Neither illumos nor Solaris supports static linking to these system libraries.

With this change, using the same setup as described in prometheus/node_exporter#1836, I'm able to build node_exporter.