### PR TITLE
Produce ZIP archives for Windows releases

### DIFF
--- a/doc/examples/crossbuild/.promu.yml
+++ b/doc/examples/crossbuild/.promu.yml
@@ -8,6 +8,7 @@ crossbuild:
     platforms:
         - linux/amd64
         - linux/386
+        - windows/amd64
 tarball:
     files:
         - README.md

--- a/doc/examples/crossbuild/Makefile
+++ b/doc/examples/crossbuild/Makefile
@@ -14,8 +14,13 @@
 # The crossbuild command sets the PREFIX env var for each platform
 PREFIX                  ?= $(shell pwd)
 
+# Workaround to mimic promu's build behavior which usually handles the extension.
+ifeq ($(GOOS),windows)
+	EXTENSION = .exe
+endif
+
 build:
-	go build -o $(PREFIX)/crossbuild-example
+	go build -o $(PREFIX)/crossbuild-example$(EXTENSION)
 
 test:
 	go test

--- a/doc/examples/crossbuild/README.md
+++ b/doc/examples/crossbuild/README.md
@@ -1,6 +1,6 @@
 Crossbuild example
 
-Run `promu crossbuild` to crossbuild for linux-386 and linux-amd64 platforms.
+Run `promu crossbuild` to crossbuild for linux-386, linux-amd64, and windows-amd64 platforms.
 Output will be in the `.build` directory.
 
 Run `promu crossbuild tarballs` to build platform tarballs.

--- a/main_test.go
+++ b/main_test.go
@@ -181,6 +181,7 @@ func TestPromuCrossbuild(t *testing.T) {
 	errcheck(t, err, string(output))
 	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".build", "linux-386", "crossbuild-example"))
 	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".build", "linux-amd64", "crossbuild-example"))
+	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".build", "windows-amd64", "crossbuild-example.exe"))
 
 	cmd = exec.Command(promuBinaryAbsPath, "crossbuild", "tarballs")
 	cmd.Dir = promuExamplesCrossbuild
@@ -189,4 +190,6 @@ func TestPromuCrossbuild(t *testing.T) {
 	errcheck(t, err, string(output))
 	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".tarballs", "promu-0.1.linux-386.tar.gz"))
 	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".tarballs", "promu-0.1.linux-amd64.tar.gz"))
+	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".tarballs", "promu-0.1.windows-amd64.tar.gz"))
+	assertFileExists(t, path.Join(promuExamplesCrossbuild, ".tarballs", "promu-0.1.windows-amd64.zip"))
 }


### PR DESCRIPTION
On Windows systems tar isn't available by default. This change creates
additional archives in the ZIP format. The tar.gz archive format on
Windows platform is kept for backwards compatibility as some users might
have written custom release scripts assuming this format.

Fixes #46