### PR TITLE
Explicitly specify promu binary name and path config

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -5,6 +5,9 @@ go:
 repository:
     path: github.com/prometheus/promu
 build:
+    binaries:
+        - name: promu
+          path: .
     flags: -mod=vendor -a -tags 'netgo static_build'
     ldflags: |
         -s


### PR DESCRIPTION
This commit makes it so the `make build` target will not rely on the
default behaviour for guessing promu's binary name and path when
building promu with promu.

This is useful when the repo dir name is not `promu` (e.g. in a fork).
Without this change the binary that is built would be named after the
repo root directory's name, which may be unexpected.
With this change the built binary will always be names `promu`.