### PR TITLE
Use regexp for crossbuild platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Commands:
   check licenses [<flags>] [<location>...]
     Inspect source files for each file in a given directory
 
+  check changelog [<flags>]
+    Check that CHANGELOG.md follows the guidelines
+
   checksum [<location>...]
     Calculate the SHA256 checksum for each file in the given location
 
@@ -39,7 +42,6 @@ Commands:
 
   version [<flags>]
     Print the version and exit
-
 ```
 
 ## `.promu.yml` config file
@@ -48,7 +50,7 @@ See documentation example [here](doc/examples/prometheus/.promu.yml)
 
 ## Compatibility
 
-* Go 1.12+
+* Go 1.14+
 
 ## More information
 

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/promu/pkg/repository"
@@ -239,6 +240,16 @@ func stringInSlice(needle string, haystack []string) bool {
 		}
 	}
 	return false
+}
+
+func inSliceRE(needle *regexp.Regexp, haystack []string) []string {
+	var list []string
+	for _, hay := range haystack {
+		if needle.MatchString(hay) {
+			list = append(list, hay)
+		}
+	}
+	return list
 }
 
 func stringInMapKeys(needle string, haystack map[string][]string) bool {


### PR DESCRIPTION
Handle the platforms list in crossbuild with a regexp. Allows for
simpler build lists like `promu crossbuild -p linux`.
* Mostly backwards compatible.
* Eliminiates the need to maintain an ARM alias list.

Signed-off-by: Ben Kochie <superq@gmail.com>