### PR TITLE
Set build date from SOURCE_DATE_EPOCH

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -147,13 +147,7 @@ func getLdflags(info repository.Info) string {
 	var ldflags []string
 
 	if len(strings.TrimSpace(config.Build.LDFlags)) > 0 {
-		var buildDate time.Time
-		unixBuildDate, err := strconv.ParseInt(os.Getenv("SOURCE_DATE_EPOCH"), 10, 64)
-		if err == nil {
-			buildDate = time.Unix(unixBuildDate, 0)
-		} else {
-			buildDate = time.Now()
-		}
+		buildDate := getBuildDate()
 		var (
 			tmplOutput = new(bytes.Buffer)
 			fnMap      = template.FuncMap{
@@ -189,6 +183,23 @@ func getLdflags(info repository.Info) string {
 	}
 
 	return strings.Join(ldflags[:], " ")
+}
+
+func getBuildDate() time.Time {
+	var buildDate time.Time
+
+	sourceDate := os.Getenv("SOURCE_DATE_EPOCH")
+	if sourceDate == "" {
+		buildDate = time.Now()
+	} else {
+		unixBuildDate, err := strconv.ParseInt(sourceDate, 10, 64)
+		if err != nil {
+			fatal(errors.Wrap(err, "Failed to parse SOURCE_DATE_EPOCH"))
+		} else {
+			buildDate = time.Unix(unixBuildDate, 0)
+		}
+	}
+	return buildDate
 }
 
 // UserFunc returns the current username.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -146,10 +147,17 @@ func getLdflags(info repository.Info) string {
 	var ldflags []string
 
 	if len(strings.TrimSpace(config.Build.LDFlags)) > 0 {
+		var buildDate time.Time
+		unixBuildDate, err := strconv.ParseInt(os.Getenv("SOURCE_DATE_EPOCH"), 10, 64)
+		if err == nil {
+			buildDate = time.Unix(unixBuildDate, 0)
+		} else {
+			buildDate = time.Now()
+		}
 		var (
 			tmplOutput = new(bytes.Buffer)
 			fnMap      = template.FuncMap{
-				"date":     time.Now().UTC().Format,
+				"date":     buildDate.UTC().Format,
 				"host":     os.Hostname,
 				"repoPath": RepoPathFunc,
 				"user":     UserFunc,


### PR DESCRIPTION
Allow to override build date with SOURCE_DATE_EPOCH
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This PR was done while working on [reproducible builds for
openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).

Signed-off-by: Witek Bedyk <witold.bedyk@suse.com>