### PR TITLE
Remove ioutil

### DIFF
--- a/cmd/checksum_test.go
+++ b/cmd/checksum_test.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"crypto/sha256"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -24,7 +23,7 @@ import (
 )
 
 func TestCalculateSHA256s(t *testing.T) {
-	dir, err := ioutil.TempDir("", "promu")
+	dir, err := os.MkdirTemp("", "promu")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +35,7 @@ func TestCalculateSHA256s(t *testing.T) {
 		content  = []byte("temporary file's content")
 		checksum = sha256.Sum256(content)
 	)
-	if err = ioutil.WriteFile(location, content, 0666); err != nil {
+	if err = os.WriteFile(location, content, 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/crossbuild_tarballs.go
+++ b/cmd/crossbuild_tarballs.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +23,7 @@ import (
 
 func runCrossbuildTarballs() {
 
-	dirs, err := ioutil.ReadDir(".build")
+	dirs, err := os.ReadDir(".build")
 	if err != nil {
 		fatal(err)
 	}

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -144,7 +143,7 @@ func Execute() {
 func initConfig(filename string) {
 	info(fmt.Sprintf("Using config file: %v", filename))
 
-	configData, err := ioutil.ReadFile(filename)
+	configData, err := os.ReadFile(filename)
 	checkError(err, "Unable to read config file: "+filename)
 	config = NewConfig()
 	err = yaml.Unmarshal(configData, config)
@@ -206,7 +205,7 @@ func fileExists(path ...string) bool {
 
 // readFile reads a file and return the trimmed output
 func readFile(path string) string {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}

--- a/pkg/repository/info.go
+++ b/pkg/repository/info.go
@@ -16,7 +16,6 @@ package repository
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -148,7 +147,7 @@ func repoLocation(repo string) (string, error) {
 
 func findVersion() (string, error) {
 	for _, file := range []string{"VERSION", "version/VERSION"} {
-		b, err := ioutil.ReadFile(file)
+		b, err := os.ReadFile(file)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>