### PR TITLE
Add the ability to override tags per GOOS

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -5,7 +5,10 @@ go:
 repository:
     path: github.com/prometheus/promu
 build:
-    flags: -a -tags 'netgo static_build'
+    tags:
+      all: [netgo, static_build]
+      windows: [static_build]
+    flags: -a
     ldflags: |
         -s
         -X github.com/prometheus/common/version.Version={{.Version}}

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -47,6 +47,7 @@ type Config struct {
 		Flags      string
 		LDFlags    string
 		ExtLDFlags []string
+		Tags       map[string][]string
 		Prefix     string
 		Static     bool
 	}


### PR DESCRIPTION
This is needed because of regressions in go1.19 which uses DNS resolution from go and can't resolve localhost anymore.

https://github.com/prometheus/prometheus/issues/11480

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>