### PR TITLE
Workaround for CVE-2022-24765

### DIFF
--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -217,6 +217,7 @@ func (pg platformGroup) buildThread(repoPath string, p int) error {
 
 	ctrName := "promu-crossbuild-" + pg.Name + strconv.FormatInt(time.Now().Unix(), 10) + "-" + strconv.Itoa(p)
 	err = sh.RunCommand("docker", "create", "-t",
+		"--env", "GIT_CEILING_DIRECTORIES=/",
 		"--name", ctrName,
 		pg.DockerImage,
 		"-i", repoPath,


### PR DESCRIPTION
Defined GIT_CEILING_DIRECTORIES environment variable to contain the root directory "/" to permit builds in trusted environments.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>