### PR TITLE
Do not discover user/host for reproducible builds

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -210,26 +210,30 @@ func getBuildDate() time.Time {
 }
 
 func HostFunc() string {
-	if os.Getenv(sourceDateEpoch) == "" {
+	if isReproducibleBuild() {
+		return "reproducible"
+	} else {
 		hostname, err := os.Hostname()
 		if err != nil {
 			return "unknown-host"
 		} else {
 			return hostname
 		}
-	} else {
-		return "reproducible"
 	}
 }
 
 // UserFunc returns the current username.
 func UserFunc() (interface{}, error) {
-	if os.Getenv(sourceDateEpoch) == "" {
+	if isReproducibleBuild() {
+		return "reproducible", nil
+	} else {
 		// os/user.Current() doesn't always work without CGO
 		return shellOutput("whoami"), nil
-	} else {
-		return "reproducible", nil
 	}
+}
+
+func isReproducibleBuild() bool {
+	return os.Getenv(sourceDateEpoch) != ""
 }
 
 // RepoPathFunc returns the repository path.


### PR DESCRIPTION
Allow to overwrite build user if SOURCE_DATE_EPOCH is set in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).