### PR TITLE
fix exmaple/prometheus build error

### DIFF
--- a/doc/examples/prometheus/.promu.yml
+++ b/doc/examples/prometheus/.promu.yml
@@ -1,4 +1,3 @@
-verbose: false
 go:
     version: 1.15.1
     cgo: false


### PR DESCRIPTION

### How to reproduce

```bash
cd doc/exmaple/prometheus
promu build
```
I got
```txt
Unable to parse config file: .promu.yml
!! yaml: unmarshal errors:
  line 1: field verbose not found in type cmd.Config
```
![image](https://github.com/prometheus/promu/assets/25921552/1e86a979-56c1-4a9f-a6b6-94dfdbc1e2e2)

### Find the problem

1. In `/doc/examples/prometheus/.promu.yml#L1`, there is a `verbose` parameter.
https://github.com/prometheus/promu/blob/570796fcc6310e062a6bc17cf981887b16b2a8fa/doc/examples/prometheus/.promu.yml#L1
2. However, there is no verbose parameter in  `Promu Command Configuration`
https://github.com/prometheus/promu/blob/570796fcc6310e062a6bc17cf981887b16b2a8fa/cmd/promu.go#L44
3.Therefore, an error occurred while parsing the configuration
https://github.com/prometheus/promu/blob/570796fcc6310e062a6bc17cf981887b16b2a8fa/cmd/promu.go#L150

