### PR TITLE
Add codesign utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,42 @@ usage: promu [<flags>] <command> [<args> ...]
 promu is the utility tool for building and releasing Prometheus projects
 
 Flags:
-  -h, --help                 Show context-sensitive help (also try --help-long and --help-man).
+  -h, --[no-]help            Show context-sensitive help (also try --help-long and --help-man).
   -c, --config=".promu.yml"  Path to config file
-  -v, --verbose              Verbose output
+  -v, --[no-]verbose         Verbose output
 
 Commands:
-  help [<command>...]
+help [<command>...]
     Show help.
 
-  build [<flags>] [<binary-names>...]
+build [<flags>] [<binary-names>...]
     Build a Go project
 
-  check licenses [<flags>] [<location>...]
+check licenses [<flags>] [<location>...]
     Inspect source files for each file in a given directory
 
-  check changelog [<flags>]
+check changelog [<flags>]
     Check that CHANGELOG.md follows the guidelines
 
-  checksum [<location>...]
+checksum [<location>...]
     Calculate the SHA256 checksum for each file in the given location
 
-  crossbuild [<flags>] [<tarballs>]
+codesign <path>
+    Code sign the darwin binary using rcodesign.
+
+crossbuild [<flags>] [<tarballs>]
     Crossbuild a Go project using Golang builder Docker images
 
-  info
+info
     Print info about current project and exit
 
-  release [<flags>] [<location>...]
+release [<flags>] [<location>...]
     Upload all release files to the Github release
 
-  tarball [<flags>] [<location>...]
+tarball [<flags>] [<location>...]
     Create a tarball from the built Go project
 
-  version [<flags>]
+version [<flags>]
     Print the version and exit
 ```
 

--- a/cmd/codesign.go
+++ b/cmd/codesign.go
@@ -1,0 +1,51 @@
+// Copyright © 2024 Prometheus Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/prometheus/promu/util/sh"
+)
+
+var (
+	codesigncmd = app.Command("codesign", "Code sign the darwin binary using rcodesign.")
+	binaryPath  = codesigncmd.Arg("path", "Absolute path to binary to be signed").Required().String()
+)
+
+func runCodeSign(binaryPath string) {
+	codeSignGoBinary(binaryPath)
+}
+
+func codeSignGoBinary(binaryPath string) {
+	var (
+		goVersion              = config.Go.Version
+		dockerMainBuilderImage = fmt.Sprintf("%s:%s-main", dockerBuilderImageName, goVersion)
+		mountPath              = fmt.Sprintf("/%s", filepath.Base(binaryPath))
+		mountPathConcat        = fmt.Sprintf("%s:%s", binaryPath, mountPath)
+	)
+	fmt.Printf("> using rcodesign to sign the binary file at path %s\n", binaryPath)
+
+	// Example:
+	// docker run --entrypoint "rcodesign" --rm -v "/path/to/darwin-arm64/node_exporter:/node_exporter"
+	// quay.io/prometheus/golang-builder:1.21-main sign /node_exporter
+	err := sh.RunCommand("docker", "run", "--entrypoint",
+		"rcodesign", "--rm", "-v", mountPathConcat,
+		dockerMainBuilderImage, "sign", mountPath)
+	if err != nil {
+		fmt.Printf("Couldn't sign the binary as intended: %s", err)
+	}
+}

--- a/cmd/promu.go
+++ b/cmd/promu.go
@@ -137,6 +137,8 @@ func Execute() {
 		runTarball(optArg(*tarBinariesLocation, 0, "."))
 	case versioncmd.FullCommand():
 		runVersion()
+	case codesigncmd.FullCommand():
+		runCodeSign(*binaryPath)
 	}
 }
 


### PR DESCRIPTION
Calls on `rcodesign` to code sign a target binary.

TODO:
- [x] ~Add tests~ (no good way of doing this, `rcodesign verify` does not work very well with this warning: ```(the verify command is known to be buggy and gives misleading results; we highly recommend using Apple's tooling until this message is removed)```
- [x] Other, based on feedback