### PR TITLE
Revert "improve: honor CGO_ENABLED env variable if it is set"

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -128,14 +128,11 @@ func runBuild(binariesString string) {
 
 	ldflags = getLdflags(projInfo)
 
-	if os.Getenv("CGO_ENABLED") == "" {
-		os.Setenv("CGO_ENABLED", "0")
-		defer os.Unsetenv("CGO_ENABLED")
-	}
+	os.Setenv("CGO_ENABLED", "0")
 	if cgo {
 		os.Setenv("CGO_ENABLED", "1")
-		defer os.Unsetenv("CGO_ENABLED")
 	}
+	defer os.Unsetenv("CGO_ENABLED")
 
 	if binariesString == "all" {
 		buildAll(ext, prefix, ldflags, getTags(config.Build.Tags), binaries)


### PR DESCRIPTION
The use of `go.cgo` in the config file is the intended method of controlling `CGO_ENABLED`. This is intentional and by design to make sure the build environment is controlled by promu.

Reverts prometheus/promu#327