### PR TITLE
Fix short version print

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,7 +27,7 @@ var (
 
 func runVersion() {
 	if *short {
-		fmt.Printf(version.Version)
+		fmt.Println(version.Version)
 	} else {
 		fmt.Println(version.Print("promu"))
 	}


### PR DESCRIPTION
Use Println to correctly print the short version string with a newline.
* Also fixes govet error.