### PR TITLE
chore: Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v1.64.6
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,43 @@
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
+version: "2"
 linters:
-  disable:
-    - errcheck
-    - unused
   enable:
     - errorlint
     - gocritic
+    - revive
+  disable:
+    - errcheck
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
     - gofumpt
     - goimports
-    - govet
-    - revive
-    - staticcheck
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/prometheus/promu
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: true
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/prometheus/promu
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.64.6
+GOLANGCI_LINT_VERSION ?= v2.0.2
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -168,11 +168,11 @@ func getLdflags(info repository.Info) string {
 
 		tmpl, err := template.New("ldflags").Funcs(fnMap).Parse(ldflagsTmpl)
 		if err != nil {
-			fatal(fmt.Errorf("Failed to parse ldflags text/template: %w", err))
+			fatal(fmt.Errorf("failed to parse ldflags text/template: %w", err))
 		}
 
 		if err := tmpl.Execute(tmplOutput, info); err != nil {
-			fatal(fmt.Errorf("Failed to execute ldflags text/template: %w", err))
+			fatal(fmt.Errorf("failed to execute ldflags text/template: %w", err))
 		}
 
 		ldflags = append(ldflags, strings.Split(tmplOutput.String(), "\n")...)
@@ -201,7 +201,7 @@ func getBuildDate() time.Time {
 	} else {
 		unixBuildDate, err := strconv.ParseInt(sourceDate, 10, 64)
 		if err != nil {
-			fatal(fmt.Errorf("Failed to parse %s: %w", sourceDateEpoch, err))
+			fatal(fmt.Errorf("failed to parse %s: %w", sourceDateEpoch, err))
 		} else {
 			buildDate = time.Unix(unixBuildDate, 0)
 		}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -49,7 +49,7 @@ func runCheckLicenses(path string, n int, extensions []string) {
 
 	filesMissingHeaders, err := checkLicenses(path, n, extensions)
 	if err != nil {
-		fatal(fmt.Errorf("Failed to check files for license header: %w", err))
+		fatal(fmt.Errorf("failed to check files for license header: %w", err))
 	}
 
 	for _, file := range filesMissingHeaders {

--- a/cmd/checksum.go
+++ b/cmd/checksum.go
@@ -35,17 +35,17 @@ var (
 func runChecksum(path string) {
 	checksums, err := calculateSHA256s(path)
 	if err != nil {
-		fatal(fmt.Errorf("Failed to calculate checksums: %w", err))
+		fatal(fmt.Errorf("failed to calculate checksums: %w", err))
 	}
 
 	file, err := os.Create(filepath.Join(path, checksumsFilename))
 	if err != nil {
-		fatal(fmt.Errorf("Failed to create checksums file: %w", err))
+		fatal(fmt.Errorf("failed to create checksums file: %w", err))
 	}
 	defer file.Close()
 	for _, c := range checksums {
 		if _, err := fmt.Fprintf(file, "%x  %s\n", c.checksum, c.filename); err != nil {
-			fatal(fmt.Errorf("Failed to write to checksums file: %w", err))
+			fatal(fmt.Errorf("failed to write to checksums file: %w", err))
 		}
 	}
 }

--- a/cmd/crossbuild.go
+++ b/cmd/crossbuild.go
@@ -157,13 +157,13 @@ func runCrossbuild() {
 		// In non-CGO, use the `base` image without any crossbuild toolchain.
 		pg := &platformGroup{"base", dockerBaseBuilderImage, allPlatforms}
 		if err := pg.Build(repoPath); err != nil {
-			fatal(fmt.Errorf("The %s builder docker image exited unexpectedly: %w", pg.Name, err))
+			fatal(fmt.Errorf("the %s builder docker image exited unexpectedly: %w", pg.Name, err))
 		}
 	} else {
 		// In CGO, use the `main` image with crossbuild toolchain.
 		pg := &platformGroup{"main", dockerMainBuilderImage, allPlatforms}
 		if err := pg.Build(repoPath); err != nil {
-			fatal(fmt.Errorf("The %s builder docker image exited unexpectedly: %w", pg.Name, err))
+			fatal(fmt.Errorf("the %s builder docker image exited unexpectedly: %w", pg.Name, err))
 		}
 	}
 }

--- a/cmd/tarball.go
+++ b/cmd/tarball.go
@@ -64,7 +64,7 @@ func runTarball(binariesLocation string) {
 	dir := filepath.Join(tmpDir, name)
 
 	if err := os.MkdirAll(dir, 0o777); err != nil {
-		fatal(fmt.Errorf("Failed to create directory: %w", err))
+		fatal(fmt.Errorf("failed to create directory: %w", err))
 	}
 	defer sh.RunCommand("rm", "-rf", tmpDir)
 
@@ -92,7 +92,7 @@ func runTarball(binariesLocation string) {
 		archive := name + ".zip"
 		fmt.Println(" >  ", archive)
 		if err := createZIP(filepath.Join(prefix, archive), dir); err != nil {
-			fatal(fmt.Errorf("Could not create ZIP archive: %w", err))
+			fatal(fmt.Errorf("could not create ZIP archive: %w", err))
 		}
 	}
 }


### PR DESCRIPTION
- Migrate the configuration file
- Update the tooling version and CI
- Apply auto-fixes

Supersedes #342
xref: https://github.com/prometheus/prometheus/pull/16356


Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
